### PR TITLE
Allow [[cms::sa_allow]] to be attached to statments

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6329,12 +6329,6 @@ static void handleCMSThreadGuardAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 static void handleCMSSaAllowAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
     assert(!AL.isInvalid());
 
-    if (!(isa<Decl>(D))) {
-      S.Diag(AL.getLoc(), diag::warn_attribute_wrong_decl_type)
-        << AL.getName();
-      return;
-    }
-
     D->addAttr(::new (S.Context) CMSSaAllowAttr(AL.getRange(), S.Context,
                                                    AL.getAttributeSpellingListIndex()));
 }


### PR DESCRIPTION
This removes the restriction that the cms::sa_allow attribute can only be attached to Decls. This will allow add the attribute to CXXTryCatchStmt.