### PR TITLE
Add EventSetupRecord::get checker

### DIFF
--- a/clang-tools-extra/clang-tidy/cms/CMSTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/cms/CMSTidyModule.cpp
@@ -11,6 +11,7 @@
 #include "../ClangTidyModule.h"
 #include "../ClangTidyModuleRegistry.h"
 #include "HandleCheck.h"
+#include "ESRecordGetCheck.h"
 
 namespace clang {
 namespace tidy {
@@ -21,6 +22,8 @@ public:
   void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
     CheckFactories.registerCheck<HandleCheck>(
         "cms-handle");
+    CheckFactories.registerCheck<ESRecordGetCheck>(
+        "cms-esrget");
   }
 };
 

--- a/clang-tools-extra/clang-tidy/cms/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/cms/CMakeLists.txt
@@ -3,7 +3,8 @@ set(LLVM_LINK_COMPONENTS support)
 add_clang_library(clangTidyCMSModule
   CMSTidyModule.cpp
   HandleCheck.cpp
-
+  ESRecordGetCheck.cpp
+  
   LINK_LIBS
   clangAST
   clangASTMatchers

--- a/clang-tools-extra/clang-tidy/cms/ESRecordGetCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cms/ESRecordGetCheck.cpp
@@ -1,0 +1,91 @@
+//===--- ESRecordGetCheck.cpp - clang-tidy--------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "ESRecordGetCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include <iostream>
+
+using namespace clang::ast_matchers;
+namespace clang {
+namespace tidy {
+namespace cms {
+
+const std::string esgettoken = "ESGetToken";
+const std::string eshandle = "ESHandle";
+const std::string esrecord = "EventSetupRecord";
+const std::string get = "get";
+const std::string thisp = "this->";
+
+
+void ESRecordGetCheck::registerMatchers(MatchFinder *Finder) {
+//  auto edmESGetToken = cxxRecordDecl(hasName("edm::ESGetToken"));
+//  auto edmESHandle = cxxRecordDecl(hasName("edm::ESHandle"));
+//  auto edmEventSetup = cxxRecordDecl(hasName("edm::EventSetup"));
+//  auto edmESRecord = cxxRecordDecl(hasName("edm::EventSetupReord"));
+//
+//  auto edmESHandleVarRef = declRefExpr(
+//                           hasDeclaration(varDecl()),
+//                           hasType(edmESHandle));
+//  auto edmGetTokenRef = declRefExpr(
+//                           hasDeclaration(varDecl()),
+//                           hasType(edmESGetToken));
+//  auto edmEventSetupRef = declRefExpr(
+//                       hasDeclaration(varDecl()),
+//                       hasType(edmEventSetup));
+//  
+  auto ESRecord = cxxRecordDecl(
+                            isSameOrDerivedFrom("EventSetupRecord")
+                          );
+
+  auto ESRgetDecl = cxxMethodDecl(
+                           hasName("get"),
+                           ofClass(ESRecord)
+                         );
+
+  auto getCall = cxxMemberCallExpr(
+                          callee(ESRgetDecl)
+                        ).bind("getcallexpr");
+
+  Finder->addMatcher(getCall,this);
+}
+
+void ESRecordGetCheck::report(CXXMemberCallExpr const * matchedCallExpr, calltype ct) {
+  if (matchedCallExpr){
+    clang::LangOptions LangOpts;
+    LangOpts.CPlusPlus = true;
+    clang::PrintingPolicy Policy(LangOpts);
+    std::string replacement;
+    auto callstart = matchedCallExpr->getBeginLoc();
+    auto callend = matchedCallExpr->getEndLoc();
+    std::string bufferi;
+    llvm::raw_string_ostream outputi(bufferi);
+    matchedCallExpr->printPretty(outputi,0,Policy);
+    replacement=outputi.str();
+    switch (ct) {
+      case direct : {
+        auto callrange = SourceRange(callstart,callend);
+        diag(callstart, StringRef("direct call of function EventSetupRecord::get(ESHandle&) is deprecated and should be replaced with a call to EventSetup::getHandle(ESGetToken&). To use ESGetToken see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#In_ED_module To get data with the token see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#Getting_data_from_EventSetup_wit"), DiagnosticIDs::Warning);
+//          << FixItHint::CreateReplacement(callrange, StringRef(replacement));
+        break;
+      };
+    }
+  }
+}
+
+void ESRecordGetCheck::check(const MatchFinder::MatchResult &Result) {
+  if (const auto *matchedCallExpr = Result.Nodes.getNodeAs<CXXMemberCallExpr>("getcallexpr")) {
+         report(matchedCallExpr,direct);
+  }
+}
+
+
+} // namespace cms
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/cms/ESRecordGetCheck.h
+++ b/clang-tools-extra/clang-tidy/cms/ESRecordGetCheck.h
@@ -1,0 +1,40 @@
+//===--- ESRecordGetCheck.h - clang-tidy------------------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_CMS_ESRGET_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_CMS_ESRGET_H
+
+#include "../ClangTidy.h"
+#include "../ClangTidyCheck.h"
+#include <llvm/Support/SaveAndRestore.h>
+
+namespace clang {
+namespace tidy {
+namespace cms {
+
+/// FIXME: Write a short description.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/esrget.html
+class ESRecordGetCheck : public ClangTidyCheck {
+public:
+  ESRecordGetCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  enum calltype {direct};
+  void report(CXXMemberCallExpr const * matchedCallExpr, calltype);
+
+};
+
+} // namespace cms
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_CMS_ESRGET_H

--- a/clang-tools-extra/test/clang-tidy/checkers/cms-eventsetuprecord-get.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cms-eventsetuprecord-get.cpp
@@ -1,0 +1,99 @@
+// RUN: %check_clang_tidy %s cms-esrget %t
+
+namespace std {
+  class string {
+  public:
+    string() {};
+    string(char * m): m_t(m) {}
+    char * m_t;
+  };
+}
+
+namespace edm {
+  template <typename ESProduct, typename ESRecord>
+  class ESGetToken {
+  };
+
+
+  template <typename T>
+  class ESHandle {
+  public:
+    ESHandle() {};
+    ESHandle(T const* m): m_t(m) {}
+    T* m_t;
+    T const& operator*() {return *m_t;};
+    T const* operator->() const {return m_t;};
+    explicit operator bool () const {return not( m_t == nullptr);};
+    bool operator!() const { return m_t == nullptr;};
+  };
+
+  class EventSetupRecord {
+  public:
+    template <typename T>
+    bool get(ESHandle<T>&);
+    
+    template <typename T>
+    bool get(std::string const&, ESHandle<T>&);
+
+  };
+  
+  class EventSetup {
+  public:
+    template <typename Rec>
+    Rec get() { return Rec{}; }
+
+    template <typename T, typename R>
+    ESHandle<T> getHandle(const ESGetToken<T, R>& iToken) const {
+      return ESHandle<T>{};
+    };
+  };
+}
+
+struct FooR : public edm::EventSetupRecord {};
+struct FooP {};
+
+class Bar {
+public:
+  bool doWork(edm::EventSetup& iSetup, edm::ESGetToken<FooP, FooR> const& token);
+  edm::ESGetToken<FooP, FooR> m_token;
+  edm::ESHandle<FooP> m_handle;
+};
+
+bool Bar::doWork(edm::EventSetup& iSetup, edm::ESGetToken<FooP, FooR> const& token) {
+  // this should give warning
+  edm::ESHandle<FooP> handle;
+  iSetup.get<FooR>().get(handle);
+// CHECK-MESSAGES: :[[@LINE-1]]:3: warning: direct call of function EventSetupRecord::get(ESHandle&) is deprecated and should be replaced with a call to EventSetup::getHandle(ESGetToken&). To use ESGetToken see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#In_ED_module To get data with the token see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#Getting_data_from_EventSetup_wit [cms-esrget]
+// CHECK-FIXES: {{^}}  iSetup.get<FooR>().get(handle);{{$}}
+  iSetup.get<FooR>().get("", handle);
+// CHECK-MESSAGES: :[[@LINE-1]]:3: warning: direct call of function EventSetupRecord::get(ESHandle&) is deprecated and should be replaced with a call to EventSetup::getHandle(ESGetToken&). To use ESGetToken see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#In_ED_module To get data with the token see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#Getting_data_from_EventSetup_wit [cms-esrget]
+
+  // this would be the replacement
+  handle = iSetup.getHandle(token);
+
+  edm::EventSetupRecord ESR;
+  ESR.get( handle );
+// CHECK-MESSAGES: :[[@LINE-1]]:3: warning: direct call of function EventSetupRecord::get(ESHandle&) is deprecated and should be replaced with a call to EventSetup::getHandle(ESGetToken&). To use ESGetToken see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#In_ED_module To get data with the token see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#Getting_data_from_EventSetup_wit [cms-esrget]
+  ESR.get("test", handle);
+// CHECK-MESSAGES: :[[@LINE-1]]:3: warning: direct call of function EventSetupRecord::get(ESHandle&) is deprecated and should be replaced with a call to EventSetup::getHandle(ESGetToken&). To use ESGetToken see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#In_ED_module To get data with the token see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#Getting_data_from_EventSetup_wit [cms-esrget]
+  
+  edm::EventSetupRecord * PESR = &ESR;
+  PESR->get( handle );
+// CHECK-MESSAGES: :[[@LINE-1]]:3: warning: direct call of function EventSetupRecord::get(ESHandle&) is deprecated and should be replaced with a call to EventSetup::getHandle(ESGetToken&). To use ESGetToken see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#In_ED_module To get data with the token see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#Getting_data_from_EventSetup_wit [cms-esrget]
+  PESR->get("test", handle);
+// CHECK-MESSAGES: :[[@LINE-1]]:3: warning: direct call of function EventSetupRecord::get(ESHandle&) is deprecated and should be replaced with a call to EventSetup::getHandle(ESGetToken&). To use ESGetToken see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#In_ED_module To get data with the token see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#Getting_data_from_EventSetup_wit [cms-esrget]
+
+  FooR fooR;
+  fooR.get( handle );
+// CHECK-MESSAGES: :[[@LINE-1]]:3: warning: direct call of function EventSetupRecord::get(ESHandle&) is deprecated and should be replaced with a call to EventSetup::getHandle(ESGetToken&). To use ESGetToken see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#In_ED_module To get data with the token see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#Getting_data_from_EventSetup_wit [cms-esrget]
+  fooR.get("test", handle);
+// CHECK-MESSAGES: :[[@LINE-1]]:3: warning: direct call of function EventSetupRecord::get(ESHandle&) is deprecated and should be replaced with a call to EventSetup::getHandle(ESGetToken&). To use ESGetToken see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#In_ED_module To get data with the token see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#Getting_data_from_EventSetup_wit [cms-esrget]
+  
+  edm::EventSetupRecord * pFooR = &fooR;
+  pFooR->get( handle );
+// CHECK-MESSAGES: :[[@LINE-1]]:3: warning: direct call of function EventSetupRecord::get(ESHandle&) is deprecated and should be replaced with a call to EventSetup::getHandle(ESGetToken&). To use ESGetToken see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#In_ED_module To get data with the token see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#Getting_data_from_EventSetup_wit [cms-esrget]
+  pFooR->get("test", handle);
+// CHECK-MESSAGES: :[[@LINE-1]]:3: warning: direct call of function EventSetupRecord::get(ESHandle&) is deprecated and should be replaced with a call to EventSetup::getHandle(ESGetToken&). To use ESGetToken see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#In_ED_module To get data with the token see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#Getting_data_from_EventSetup_wit [cms-esrget]
+
+  return true;
+}


### PR DESCRIPTION
This clang-tidy checker will flag all uses up EventSetupRecord::get with a deprecated warning, Links to wiki pages with directions on replacement with EventSetup::getHandle(ESGetToken<>) are also printed.
Resolves https://github.com/makortel/framework/issues/69