### PR TITLE
Don't flag EventSetupRecord::get calls if first argument is of type ESGetToken

### DIFF
--- a/clang-tools-extra/clang-tidy/cms/ESRecordGetCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cms/ESRecordGetCheck.cpp
@@ -17,31 +17,13 @@ namespace clang {
 namespace tidy {
 namespace cms {
 
-const std::string esgettoken = "ESGetToken";
-const std::string eshandle = "ESHandle";
-const std::string esrecord = "EventSetupRecord";
-const std::string get = "get";
-const std::string thisp = "this->";
-
 
 void ESRecordGetCheck::registerMatchers(MatchFinder *Finder) {
-//  auto edmESGetToken = cxxRecordDecl(hasName("edm::ESGetToken"));
-//  auto edmESHandle = cxxRecordDecl(hasName("edm::ESHandle"));
-//  auto edmEventSetup = cxxRecordDecl(hasName("edm::EventSetup"));
-//  auto edmESRecord = cxxRecordDecl(hasName("edm::EventSetupReord"));
-//
-//  auto edmESHandleVarRef = declRefExpr(
-//                           hasDeclaration(varDecl()),
-//                           hasType(edmESHandle));
-//  auto edmGetTokenRef = declRefExpr(
-//                           hasDeclaration(varDecl()),
-//                           hasType(edmESGetToken));
-//  auto edmEventSetupRef = declRefExpr(
-//                       hasDeclaration(varDecl()),
-//                       hasType(edmEventSetup));
-//  
+
+  auto edmESGetToken = cxxRecordDecl(hasName("edm::ESGetToken"));
+
   auto ESRecord = cxxRecordDecl(
-                            isSameOrDerivedFrom("EventSetupRecord")
+                            isSameOrDerivedFrom(hasName("EventSetupRecord"))
                           );
 
   auto ESRgetDecl = cxxMethodDecl(
@@ -50,7 +32,8 @@ void ESRecordGetCheck::registerMatchers(MatchFinder *Finder) {
                          );
 
   auto getCall = cxxMemberCallExpr(
-                          callee(ESRgetDecl)
+                          callee(ESRgetDecl),
+                          unless(hasArgument(0,expr(hasType(edmESGetToken))))
                         ).bind("getcallexpr");
 
   Finder->addMatcher(getCall,this);

--- a/clang-tools-extra/test/clang-tidy/checkers/cms-eventsetuprecord-get.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cms-eventsetuprecord-get.cpp
@@ -36,6 +36,21 @@ namespace edm {
     bool get(std::string const&, ESHandle<T>&);
 
   };
+
+  template <typename T>
+  class EventSetupRecordImplementation : public EventSetupRecord {
+  public:
+
+    using EventSetupRecord::get;
+
+    template <typename PRODUCT>
+    PRODUCT const& get(ESGetToken<PRODUCT, T> const & iToken) const;
+
+
+    template <typename PRODUCT>
+    PRODUCT const& get(ESGetToken<PRODUCT, T>& iToken) const;
+
+  }; 
   
   class EventSetup {
   public:
@@ -51,6 +66,9 @@ namespace edm {
 
 struct FooR : public edm::EventSetupRecord {};
 struct FooP {};
+
+class ESFooR : public edm::EventSetupRecordImplementation<ESFooR> {};
+
 
 class Bar {
 public:
@@ -94,6 +112,19 @@ bool Bar::doWork(edm::EventSetup& iSetup, edm::ESGetToken<FooP, FooR> const& tok
 // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: direct call of function EventSetupRecord::get(ESHandle&) is deprecated and should be replaced with a call to EventSetup::getHandle(ESGetToken&). To use ESGetToken see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#In_ED_module To get data with the token see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#Getting_data_from_EventSetup_wit [cms-esrget]
   pFooR->get("test", handle);
 // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: direct call of function EventSetupRecord::get(ESHandle&) is deprecated and should be replaced with a call to EventSetup::getHandle(ESGetToken&). To use ESGetToken see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#In_ED_module To get data with the token see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#Getting_data_from_EventSetup_wit [cms-esrget]
+
+  return true;
+}
+
+class Baz {
+  public:
+    edm::ESGetToken<FooR, ESFooR> m_token;
+    bool doWork( ESFooR const& record);
+};
+
+bool Baz::doWork( ESFooR const& record) {
+
+  const auto& esFooR = record.get(m_token);
 
   return true;
 }


### PR DESCRIPTION
This PR updates the clang-tidy checker for EventSetupRecord::get calls.
Per discussion with Matti on FNAL Computing Spack cms-framework channel.
> The Record classes all inherit from either EventSetupRecordImplementation or DependentRecordImplementation (and Dependent... inherits from EventSetup...), and EventSetupRecordImplementation inherits from EventSetupRecord
> The get() functions of EventSetupRecord are those that should be flagged. EventSetupRecordImplementation and DependentRecordImplementation have additional get() functions that should not be flagged.
> One way to distinguish could be the argument type, if it is ESGetToken<P, R> , do not flag, if it is something else, flag it
