### PR TITLE
For the CMS mutable member checker the hash for a field declaration should be scoped.

### DIFF
--- a/clang/lib/Analysis/IssueHash.cpp
+++ b/clang/lib/Analysis/IssueHash.cpp
@@ -98,6 +98,8 @@ static std::string GetEnclosingDeclContextSignature(const Decl *D) {
     case Decl::Record:
     case Decl::CXXRecord:
     case Decl::Enum:
+    case Decl::Field:
+    case Decl::Var:
       DeclName = ND->getQualifiedNameAsString();
       break;
     case Decl::CXXConstructor:
@@ -110,9 +112,6 @@ static std::string GetEnclosingDeclContextSignature(const Decl *D) {
     case Decl::ObjCMethod:
       // ObjC Methods can not be overloaded, qualified name uniquely identifies
       // the method.
-      DeclName = ND->getQualifiedNameAsString();
-      break;
-    case Decl::FieldDecl:
       DeclName = ND->getQualifiedNameAsString();
       break;
     default:

--- a/clang/lib/Analysis/IssueHash.cpp
+++ b/clang/lib/Analysis/IssueHash.cpp
@@ -112,6 +112,9 @@ static std::string GetEnclosingDeclContextSignature(const Decl *D) {
       // the method.
       DeclName = ND->getQualifiedNameAsString();
       break;
+    case Decl::FieldDecl:
+      DeclName = ND->getQualifiedNameAsString();
+      break;
     default:
       break;
     }


### PR DESCRIPTION

This leads to reports for variables with the same name in different classes in the same translation unit getting the same hash. The output name of the report uses the hash so the last report was the only report for that variable.