### PR TITLE
Backport of pull request #12

### DIFF
--- a/clang/lib/Analysis/IssueHash.cpp
+++ b/clang/lib/Analysis/IssueHash.cpp
@@ -97,6 +97,8 @@ static std::string GetEnclosingDeclContextSignature(const Decl *D) {
     case Decl::Record:
     case Decl::CXXRecord:
     case Decl::Enum:
+    case Decl::Field:
+    case Decl::Var:
       DeclName = ND->getQualifiedNameAsString();
       break;
     case Decl::CXXConstructor:


### PR DESCRIPTION

* For the CMS mutable member checker the hash for a field declaration should be scoped. This leads to reports for variables with the same name in different classes in the same translation unit getting the same hash. The output name of the report uses the hash so the last report was the only report for that variable.

* Move to grouped Decl::'s remove Decl ending add Var